### PR TITLE
Add cart suggestions, shipping progress bar, and product recommendations

### DIFF
--- a/assets/component-free-shipping.css
+++ b/assets/component-free-shipping.css
@@ -1,0 +1,21 @@
+/* 免费配送进度条外层槽 */
+.free-shipping-bar {
+  background-color: rgba(var(--color-base-background-2), 1);
+  width: 100%;
+  height: 8px;
+  border-radius: 4px;
+  overflow: hidden;
+  margin: 8px 0;
+}
+/* 已达成的进度部分 */
+.free-shipping-progress {
+  background-color: rgba(var(--color-base-accent-1), 1);
+  height: 100%;
+  width: 0;
+}
+/* 提示文字样式 */
+.cart__free-shipping-message {
+  text-align: center;
+  font-size: 0.875rem;
+  margin-bottom: 4px;
+}

--- a/assets/component-free-shipping.css
+++ b/assets/component-free-shipping.css
@@ -1,4 +1,4 @@
-/* 免费配送进度条外层槽 */
+/* Free shipping progress bar track */
 .free-shipping-bar {
   background-color: rgba(var(--color-base-background-2), 1);
   width: 100%;
@@ -7,13 +7,13 @@
   overflow: hidden;
   margin: 8px 0;
 }
-/* 已达成的进度部分 */
+/* Filled portion of the progress bar */
 .free-shipping-progress {
   background-color: rgba(var(--color-base-accent-1), 1);
   height: 100%;
   width: 0;
 }
-/* 提示文字样式 */
+/* Message styling */
 .cart__free-shipping-message {
   text-align: center;
   font-size: 0.875rem;

--- a/sections/cart-suggestions.liquid
+++ b/sections/cart-suggestions.liquid
@@ -1,7 +1,7 @@
 {{ 'component-card.css' | asset_url | stylesheet_tag }}
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {%- style -%}
-  /* Section 内边距，保持与主题一致的上下留白 */
+  /* Section padding to match theme spacing */
   .section-{{ section.id }}-padding {
     padding-top: 36px;
     padding-bottom: 36px;

--- a/sections/cart-suggestions.liquid
+++ b/sections/cart-suggestions.liquid
@@ -1,0 +1,49 @@
+{{ 'component-card.css' | asset_url | stylesheet_tag }}
+{{ 'component-price.css' | asset_url | stylesheet_tag }}
+{%- style -%}
+  /* Section 内边距，保持与主题一致的上下留白 */
+  .section-{{ section.id }}-padding {
+    padding-top: 36px;
+    padding-bottom: 36px;
+  }
+  @media screen and (min-width: 750px) {
+    .section-{{ section.id }}-padding {
+      padding-top: 48px;
+      padding-bottom: 48px;
+    }
+  }
+{%- endstyle -%}
+
+<div class="page-width section-{{ section.id }}-padding">
+  <h2 class="h4">You may also like</h2>
+  {%- assign first_item = cart.items | first -%}
+  {%- if first_item -%}
+    {%- assign base_collection = first_item.product.collections | first -%}
+  {%- endif -%}
+  {% if base_collection %}
+    {%- assign cart_handles = cart.items | map: "product" | map: "handle" -%}
+    <ul class="grid product-grid contains-card contains-card--product{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid--4-col-desktop grid--2-col-tablet-down">
+      {%- assign count = 0 -%}
+      {%- for product in base_collection.products -%}
+        {%- unless cart_handles contains product.handle -%}
+          <li class="grid__item">
+            {% render 'card-product', 
+              card_product: product, 
+              section_id: section.id 
+            %}
+          </li>
+          {%- assign count = count | plus: 1 -%}
+          {%- if count == 4 -%}{%- break -%}{%- endif -%}
+        {%- endunless -%}
+      {%- endfor -%}
+    </ul>
+  {% endif %}
+</div>
+
+{% schema %}
+{
+  "name": "Cart Suggestions",
+  "tag": "section",
+  "settings": []
+}
+{% endschema %}

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -29,22 +29,22 @@
     <h1 class="title title--primary">{{ 'sections.cart.title' | t }}</h1>
     <a href="{{ routes.all_products_collection_url }}" class="underlined-link">{{ 'general.continue_shopping' | t }}</a>
   </div>
-  <!-- 免费配送进度条 Start -->
+  <!-- Free shipping progress bar start -->
   {% if cart != empty %}
     {% if cart.total_price < 4000 %}
       {% assign remaining = 4000 | minus: cart.total_price %}
-      <p class="cart__free-shipping-message">还差 {{ remaining | money }} 即可享受免运费！</p>
+      <p class="cart__free-shipping-message">Spend {{ remaining | money }} more to get free shipping!</p>
       <div class="free-shipping-bar">
         <div class="free-shipping-progress" style="width: {{ cart.total_price | times: 100 | divided_by: 4000 | at_most: 100 }}%;"></div>
       </div>
     {% else %}
-      <p class="cart__free-shipping-message">恭喜！您的订单已获得免运费资格。</p>
+      <p class="cart__free-shipping-message">Congrats! Your order qualifies for free shipping.</p>
       <div class="free-shipping-bar">
         <div class="free-shipping-progress" style="width: 100%;"></div>
       </div>
     {% endif %}
   {% endif %}
-  <!-- 免费配送进度条 End -->
+  <!-- Free shipping progress bar end -->
 
   <div class="cart__warnings">
     <h1 class="cart__empty-text">{{ 'sections.cart.empty' | t }}</h1>

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -4,6 +4,7 @@
 {{ 'component-price.css' | asset_url | stylesheet_tag }}
 {{ 'component-discounts.css' | asset_url | stylesheet_tag }}
 {{ 'component-loading-overlay.css' | asset_url | stylesheet_tag }}
+{{ 'component-free-shipping.css' | asset_url | stylesheet_tag }}
 
 {%- style -%}
   .section-{{ section.id }}-padding {
@@ -28,6 +29,22 @@
     <h1 class="title title--primary">{{ 'sections.cart.title' | t }}</h1>
     <a href="{{ routes.all_products_collection_url }}" class="underlined-link">{{ 'general.continue_shopping' | t }}</a>
   </div>
+    <!-- 免费配送进度条 Start -->
+    {% if cart != empty %}
+    {% if cart.total_price < 4000 %}
+    {% assign remaining = 4000 | minus: cart.total_price %}
+    <p class="cart__free-shipping-message">还差 {{ remaining | money }} 即可享受免运费！</p>
+    <div class="free-shipping-bar">
+    <div class="free-shipping-progress" style="width: {{ cart.total_price | times: 100 | divided_by: 4000 | at_most: 100 }}%;"></div>
+    </div>
+    {% else %}
+    <p class="cart__free-shipping-message">恭喜！您的订单已获得免运费资格。</p>
+    <div class="free-shipping-bar">
+    <div class="free-shipping-progress" style="width: 100%;"></div>
+    </div>
+    {% endif %}
+    {% endif %}
+    <!-- 免费配送进度条 End -->
 
   <div class="cart__warnings">
     <h1 class="cart__empty-text">{{ 'sections.cart.empty' | t }}</h1>

--- a/sections/main-cart-items.liquid
+++ b/sections/main-cart-items.liquid
@@ -29,22 +29,22 @@
     <h1 class="title title--primary">{{ 'sections.cart.title' | t }}</h1>
     <a href="{{ routes.all_products_collection_url }}" class="underlined-link">{{ 'general.continue_shopping' | t }}</a>
   </div>
-    <!-- 免费配送进度条 Start -->
-    {% if cart != empty %}
+  <!-- 免费配送进度条 Start -->
+  {% if cart != empty %}
     {% if cart.total_price < 4000 %}
-    {% assign remaining = 4000 | minus: cart.total_price %}
-    <p class="cart__free-shipping-message">还差 {{ remaining | money }} 即可享受免运费！</p>
-    <div class="free-shipping-bar">
-    <div class="free-shipping-progress" style="width: {{ cart.total_price | times: 100 | divided_by: 4000 | at_most: 100 }}%;"></div>
-    </div>
+      {% assign remaining = 4000 | minus: cart.total_price %}
+      <p class="cart__free-shipping-message">还差 {{ remaining | money }} 即可享受免运费！</p>
+      <div class="free-shipping-bar">
+        <div class="free-shipping-progress" style="width: {{ cart.total_price | times: 100 | divided_by: 4000 | at_most: 100 }}%;"></div>
+      </div>
     {% else %}
-    <p class="cart__free-shipping-message">恭喜！您的订单已获得免运费资格。</p>
-    <div class="free-shipping-bar">
-    <div class="free-shipping-progress" style="width: 100%;"></div>
-    </div>
+      <p class="cart__free-shipping-message">恭喜！您的订单已获得免运费资格。</p>
+      <div class="free-shipping-bar">
+        <div class="free-shipping-progress" style="width: 100%;"></div>
+      </div>
     {% endif %}
-    {% endif %}
-    <!-- 免费配送进度条 End -->
+  {% endif %}
+  <!-- 免费配送进度条 End -->
 
   <div class="cart__warnings">
     <h1 class="cart__empty-text">{{ 'sections.cart.empty' | t }}</h1>

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -13,6 +13,9 @@
   }
 </style>
 
+{{ 'component-card.css' | asset_url | stylesheet_tag }}
+{{ 'component-price.css' | asset_url | stylesheet_tag }}
+{{ 'component-free-shipping.css' | asset_url | stylesheet_tag }}
 <cart-drawer class="drawer{% if cart == empty %} is-empty{% endif %}">
   <div id="CartDrawer" class="cart-drawer">
     <div id="CartDrawer-Overlay" class="cart-drawer__overlay"></div>
@@ -66,6 +69,22 @@
           {% render 'icon-close' %}
         </button>
       </div>
+        <!-- 免费配送进度条 (Drawer) Start -->
+        {% if cart != empty %}
+          {% if cart.total_price < 4000 %}
+            {% assign remaining = 4000 | minus: cart.total_price %}
+            <p class="cart__free-shipping-message">还差 {{ remaining | money }} 即可免运费</p>
+            <div class="free-shipping-bar">
+              <div class="free-shipping-progress" style="width: {{ cart.total_price | times: 100 | divided_by: 4000 | at_most: 100 }}%;"></div>
+            </div>
+          {% else %}
+            <p class="cart__free-shipping-message">恭喜！已享受免费配送</p>
+            <div class="free-shipping-bar">
+              <div class="free-shipping-progress" style="width: 100%;"></div>
+            </div>
+          {% endif %}
+        {% endif %}
+        <!-- 免费配送进度条 (Drawer) End -->
       <cart-drawer-items
         {% if cart == empty %}
           class=" is-empty"
@@ -350,6 +369,35 @@
           <div id="CartDrawer-CartErrors" role="alert"></div>
         </form>
       </cart-drawer-items>
+        <!-- 加购推荐：在此新增推荐商品列表 Start -->
+        {% if cart != empty %}
+          <div class="cart-drawer__suggestions" style="padding: 16px 0;">
+            <h3 class="h4">You may also like</h3>
+            {% assign first_item = cart.items | first %}
+            {% if first_item %}
+              {% assign base_collection = first_item.product.collections | first %}
+            {% endif %}
+            {% if base_collection %}
+              {% assign cart_handles = cart.items | map: "product" | map: "handle" %}
+              <ul class="grid product-grid contains-card contains-card--product{% if settings.card_style == 'standard' %} contains-card--standard{% endif %} grid--2-col-tablet-down grid--2-col-desktop">
+                {% assign count = 0 %}
+                {% for product in base_collection.products %}
+                  {% unless cart_handles contains product.handle %}
+                    <li class="grid__item">
+                      {% render 'card-product', 
+                        card_product: product, 
+                        section_id: 'cartDrawer' 
+                      %}
+                    </li>
+                    {% assign count = count | plus: 1 %}
+                    {% if count == 4 %}{% break %}{% endif %}
+                  {% endunless %}
+                {% endfor %}
+              </ul>
+            {% endif %}
+          </div>
+        {% endif %}
+        <!-- 加购推荐：推荐商品列表 End -->
       <div class="drawer__footer">
         {%- if settings.show_cart_note -%}
           <details id="Details-CartDrawer">

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -69,24 +69,24 @@
           {% render 'icon-close' %}
         </button>
       </div>
-          <!-- 免费配送进度条 (Drawer) Start -->
+          <!-- Free shipping progress bar (drawer) start -->
           {% if cart != empty %}
             <div class="cart-drawer__shipping-goal" style="padding: 8px 16px; text-align: center;">
               {% if cart.total_price < 4000 %}
                 {% assign remaining = 4000 | minus: cart.total_price %}
-                <p class="cart__free-shipping-message">还差 {{ remaining | money }} 即可免运费</p>
+                <p class="cart__free-shipping-message">Spend {{ remaining | money }} more to get free shipping.</p>
                 <div class="free-shipping-bar">
                   <div class="free-shipping-progress" style="width: {{ cart.total_price | times: 100 | divided_by: 4000 | at_most: 100 }}%;"></div>
                 </div>
               {% else %}
-                <p class="cart__free-shipping-message">恭喜！已享受免费配送</p>
+                <p class="cart__free-shipping-message">Congrats! You're getting free shipping.</p>
                 <div class="free-shipping-bar">
                   <div class="free-shipping-progress" style="width: 100%;"></div>
                 </div>
               {% endif %}
             </div>
           {% endif %}
-          <!-- 免费配送进度条 (Drawer) End -->
+          <!-- Free shipping progress bar (drawer) end -->
       <cart-drawer-items
         {% if cart == empty %}
           class=" is-empty"
@@ -371,7 +371,7 @@
           <div id="CartDrawer-CartErrors" role="alert"></div>
         </form>
       </cart-drawer-items>
-        <!-- 加购推荐：在此新增推荐商品列表 Start -->
+        <!-- Cart suggestions start -->
         {% if cart != empty %}
           <div class="cart-drawer__suggestions" style="padding: 16px 0;">
             <h3 class="h4">You may also like</h3>
@@ -386,9 +386,9 @@
                 {% for product in base_collection.products %}
                   {% unless cart_handles contains product.handle %}
                     <li class="grid__item">
-                      {% render 'card-product', 
-                        card_product: product, 
-                        section_id: 'cartDrawer' 
+                      {% render 'card-product',
+                        card_product: product,
+                        section_id: 'cartDrawer'
                       %}
                     </li>
                     {% assign count = count | plus: 1 %}
@@ -399,7 +399,7 @@
             {% endif %}
           </div>
         {% endif %}
-        <!-- 加购推荐：推荐商品列表 End -->
+        <!-- Cart suggestions end -->
       <div class="drawer__footer">
         {%- if settings.show_cart_note -%}
           <details id="Details-CartDrawer">

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -69,22 +69,24 @@
           {% render 'icon-close' %}
         </button>
       </div>
-        <!-- 免费配送进度条 (Drawer) Start -->
-        {% if cart != empty %}
-          {% if cart.total_price < 4000 %}
-            {% assign remaining = 4000 | minus: cart.total_price %}
-            <p class="cart__free-shipping-message">还差 {{ remaining | money }} 即可免运费</p>
-            <div class="free-shipping-bar">
-              <div class="free-shipping-progress" style="width: {{ cart.total_price | times: 100 | divided_by: 4000 | at_most: 100 }}%;"></div>
-            </div>
-          {% else %}
-            <p class="cart__free-shipping-message">恭喜！已享受免费配送</p>
-            <div class="free-shipping-bar">
-              <div class="free-shipping-progress" style="width: 100%;"></div>
+          <!-- 免费配送进度条 (Drawer) Start -->
+          {% if cart != empty %}
+            <div class="cart-drawer__shipping-goal" style="padding: 8px 16px; text-align: center;">
+              {% if cart.total_price < 4000 %}
+                {% assign remaining = 4000 | minus: cart.total_price %}
+                <p class="cart__free-shipping-message">还差 {{ remaining | money }} 即可免运费</p>
+                <div class="free-shipping-bar">
+                  <div class="free-shipping-progress" style="width: {{ cart.total_price | times: 100 | divided_by: 4000 | at_most: 100 }}%;"></div>
+                </div>
+              {% else %}
+                <p class="cart__free-shipping-message">恭喜！已享受免费配送</p>
+                <div class="free-shipping-bar">
+                  <div class="free-shipping-progress" style="width: 100%;"></div>
+                </div>
+              {% endif %}
             </div>
           {% endif %}
-        {% endif %}
-        <!-- 免费配送进度条 (Drawer) End -->
+          <!-- 免费配送进度条 (Drawer) End -->
       <cart-drawer-items
         {% if cart == empty %}
           class=" is-empty"

--- a/snippets/meta-tags.liquid
+++ b/snippets/meta-tags.liquid
@@ -1,0 +1,4 @@
+{% comment %}
+  Placeholder meta tags snippet. Customize as needed.
+{% endcomment %}
+

--- a/snippets/one-trust-cookies.liquid
+++ b/snippets/one-trust-cookies.liquid
@@ -1,0 +1,4 @@
+{% comment %}
+  Placeholder for OneTrust cookies script. Add integration snippet if needed.
+{% endcomment %}
+

--- a/templates/cart.json
+++ b/templates/cart.json
@@ -7,6 +7,9 @@
         "padding_bottom": 36
       }
     },
+    "cart-suggestions": {
+      "type": "cart-suggestions"
+    },
     "cart-footer": {
       "type": "main-cart-footer",
       "blocks": {
@@ -24,9 +27,6 @@
         "buttons"
       ],
       "settings": {}
-    },
-    "cart-suggestions": {
-      "type": "cart-suggestions"
     }
   },
   "order": [

--- a/templates/cart.json
+++ b/templates/cart.json
@@ -1,1 +1,37 @@
-{"sections":{"cart-items":{"type":"main-cart-items","settings":{"padding_top":36,"padding_bottom":36}},"cart-footer":{"type":"main-cart-footer","blocks":{"subtotal":{"type":"subtotal","settings":{}},"buttons":{"type":"buttons","settings":{}}},"block_order":["subtotal","buttons"],"settings":{}}},"order":["cart-items","cart-footer"]}
+{
+  "sections": {
+    "cart-items": {
+      "type": "main-cart-items",
+      "settings": {
+        "padding_top": 36,
+        "padding_bottom": 36
+      }
+    },
+    "cart-footer": {
+      "type": "main-cart-footer",
+      "blocks": {
+        "subtotal": {
+          "type": "subtotal",
+          "settings": {}
+        },
+        "buttons": {
+          "type": "buttons",
+          "settings": {}
+        }
+      },
+      "block_order": [
+        "subtotal",
+        "buttons"
+      ],
+      "settings": {}
+    },
+    "cart-suggestions": {
+      "type": "cart-suggestions"
+    }
+  },
+  "order": [
+    "cart-items",
+    "cart-suggestions",
+    "cart-footer"
+  ]
+}

--- a/templates/product.json
+++ b/templates/product.json
@@ -1,0 +1,50 @@
+{
+  "sections": {
+    "main-product": {
+      "type": "main-product",
+      "blocks": {
+        "title": {
+          "type": "title",
+          "settings": {}
+        },
+        "price": {
+          "type": "price",
+          "settings": {}
+        },
+        "variant_picker": {
+          "type": "variant_picker",
+          "settings": {}
+        },
+        "buy_buttons": {
+          "type": "buy_buttons",
+          "settings": {}
+        },
+        "description": {
+          "type": "description",
+          "settings": {}
+        }
+      },
+      "block_order": [
+        "title",
+        "price",
+        "variant_picker",
+        "buy_buttons",
+        "description"
+      ],
+      "settings": {
+        "padding_top": 36,
+        "padding_bottom": 36
+      }
+    },
+    "related-products": {
+      "type": "related-products",
+      "settings": {
+        "heading": "You may also like"
+      }
+    }
+  },
+  "order": [
+    "main-product",
+    "related-products"
+  ]
+}


### PR DESCRIPTION
## Summary
- add related products section to product template
- show cart suggestions and shipping progress bar in cart page and drawer
- style free shipping progress with new asset

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_6894cd7672c08328a60445bb28cbc8c8