### PR TITLE
Add cart shipping progress bar and frequently bought page

### DIFF
--- a/sections/frequently-bought.liquid
+++ b/sections/frequently-bought.liquid
@@ -1,0 +1,154 @@
+<section class="frequently-bought page-width">
+  <h1>Frequently bought together</h1>
+
+  <h2>Drops</h2>
+  <ul>
+    <li>FG0300-12 SS Mint 28 ct
+      <ul>
+        <li>FG0300-10 SS LHG 28 ct</li>
+      </ul>
+    </li>
+    <li>FG0300-10 SS LHG 28 ct
+      <ul>
+        <li>FG0300-12 SS mint 28 ct</li>
+      </ul>
+    </li>
+    <li>FG0300-13 Morning Sickness Drops
+      <ul>
+        <li>FG0536-13 Morning Sickness Gummies 60 ct</li>
+        <li>FG0035-05 Post Baby High Waist (L/XL)</li>
+        <li>FG0076-11 New Berry Drink Mix</li>
+        <li>FG0005-02- Milkscreen Test Strips</li>
+      </ul>
+    </li>
+  </ul>
+
+  <h2>Gummies</h2>
+  <ul>
+    <li>FG0538-01 Strawberry Fiber Gummies
+      <ul>
+        <li>No similar product for purchase</li>
+        <li>FG0300-10 SS LHG 28 ct</li>
+        <li>FG0300-12 SS mint 28 ct</li>
+      </ul>
+    </li>
+    <li>FG0536-01 SS Gummies 50 ct
+      <ul>
+        <li>FG0300-10 SS LHG 28 ct</li>
+        <li>FG0300-12 SS mint 28 ct</li>
+      </ul>
+    </li>
+    <li>FG0160-01 Green Apple Moringa Gummies
+      <ul>
+        <li>FG0162-01 Grapes Fenugreek Gummies</li>
+        <li>FG0076-11 New Berry Drink Mix</li>
+        <li>FG0076-14 Chocolate Drink Mix</li>
+        <li>FG0074-12 Blueberry Acai</li>
+      </ul>
+    </li>
+    <li>FG0162-01 Grapes Fenugreek Gummies
+      <ul>
+        <li>FG0160-01 Green Apple Moringa Gummies</li>
+        <li>FG0074-12 Blueberry Acai</li>
+        <li>FG0076-14 Chocolate Drink Mix</li>
+        <li>FG0076-11 New Berry Drink Mix</li>
+      </ul>
+    </li>
+    <li>FG0536-13 Morning Sickness Gummies 60 ct
+      <ul>
+        <li>FG0300-13 Morning Sickness Drops</li>
+        <li>FG0300-12 SS Mint 28 ct</li>
+        <li>FG0300-10 SS LHG 28 ct</li>
+      </ul>
+    </li>
+  </ul>
+
+  <h2>Powder</h2>
+  <ul>
+    <li>FG0076-03- Orange Mango Drink Mix
+      <ul>
+        <li>FG0074-04 Elderberry Lemonade Drink Mix</li>
+        <li>FG0220-01 Shrinkx Belly Bamboo (S/M)</li>
+        <li>FG0005-02- Milkscreen Test Strips</li>
+        <li>FG0670-01 Berry Softchew</li>
+      </ul>
+    </li>
+    <li>FG0074-04 Elderberry Lemonade Drink Mix
+      <ul>
+        <li>FG0030-05 C-Panty High Waist</li>
+        <li>FG0076-03- Orange Mango Drink Mix</li>
+        <li>FG0005-02- Milkscreen Test Strips</li>
+        <li>FG0670-01 Berry Softchew</li>
+      </ul>
+    </li>
+    <li>FG0076-11 New Berry Drink Mix
+      <ul>
+        <li>FG0076-14 Chocolate Drink Mix</li>
+        <li>FG0005-02- Milkscreen Test Strips</li>
+        <li>FG0035-05 Post Baby High Waist (L/XL)</li>
+        <li>FG0670-01 Berry Softchew</li>
+      </ul>
+    </li>
+    <li>FG0670-01 Berry Softchew
+      <ul>
+        <li>FG0074-04 Elderberry Lemonade Drink Mix</li>
+        <li>FG0125-04 Capsules 100 ct</li>
+      </ul>
+    </li>
+    <li>FG0125-04 Capsules 100 ct
+      <ul>
+        <li>FG0162-01 Grapes Fenugreek Gummies</li>
+        <li>FG0076-03- Orange Mango Drink Mix</li>
+        <li>FG0074-12 Blueberry Acai</li>
+      </ul>
+    </li>
+  </ul>
+
+  <h2>Test Strips</h2>
+  <ul>
+    <li>FG0005-02- Milkscreen Test Strips
+      <ul>
+        <li>FG0220-01 Shrinkx Belly Bamboo (S/M)</li>
+        <li>FG0035-05 Post Baby High Waist (L/XL)</li>
+        <li>FG0030-05 C-Panty High Waist</li>
+      </ul>
+    </li>
+  </ul>
+
+  <h2>Apparel</h2>
+  <ul>
+    <li>FG0030-05 C-Panty High Waist
+      <ul>
+        <li>FG0300-13 Morning Sickness Drops</li>
+        <li>FG0162-01 Grapes Fenugreek Gummies</li>
+        <li>FG0005-02- Milkscreen Test Strips</li>
+      </ul>
+    </li>
+    <li>FG0035-05 Post Baby High Waist (L/XL)
+      <ul>
+        <li>FG0005-02- Milkscreen Test Strips</li>
+        <li>FG0074-12 Blueberry Acai</li>
+        <li>FG0076-14 Chocolate Drink Mix</li>
+      </ul>
+    </li>
+    <li>FG0220-01 Shrinkx Belly Bamboo (S/M)
+      <ul>
+        <li>FG0074-04 Elderberry Lemonade Drink Mix</li>
+        <li>FG0005-02- Milkscreen Test Strips</li>
+        <li>FG0160-01 Green Apple Moringa Gummies</li>
+      </ul>
+    </li>
+  </ul>
+</section>
+
+{% schema %}
+{
+  "name": "Frequently Bought Together",
+  "settings": [
+    {
+      "type": "header",
+      "content": "Static content"
+    }
+  ]
+}
+{% endschema %}

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -55,6 +55,7 @@
           {%- endif -%}
         </div>
       {%- endif -%}
+      {% render 'shipping-progress-bar', threshold: 2500 %}
       <div class="drawer__header">
         <h2 class="drawer__heading">{{ 'sections.cart.title' | t }}</h2>
         <button
@@ -371,8 +372,6 @@
           </details>
         {%- endif -%}
 
-        <!-- Start blocks -->
-        {% render 'shipping-progress-bar', threshold: 2500 %}
         <!-- Subtotals -->
 
         <div class="cart-drawer__footer" {{ block.shopify_attributes }}>

--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -372,6 +372,7 @@
         {%- endif -%}
 
         <!-- Start blocks -->
+        {% render 'shipping-progress-bar', threshold: 2500 %}
         <!-- Subtotals -->
 
         <div class="cart-drawer__footer" {{ block.shopify_attributes }}>

--- a/snippets/shipping-progress-bar.liquid
+++ b/snippets/shipping-progress-bar.liquid
@@ -25,7 +25,7 @@
 {% endif %}
 <style>
 .shipping-progress{margin-bottom:1rem;}
-.shipping-progress__track{background:#eee;height:8px;position:relative;border-radius:4px;overflow:hidden;}
-.shipping-progress__fill{background:#000;height:100%;border-radius:4px;}
-.shipping-progress__text{margin-top:0.5rem;font-size:0.875rem;}
+.shipping-progress__track{background:#eee;height:16px;position:relative;border-radius:8px;overflow:hidden;}
+.shipping-progress__fill{background:#000;height:100%;border-radius:8px;}
+.shipping-progress__text{margin-top:0.5rem;font-size:1rem;}
 </style>

--- a/snippets/shipping-progress-bar.liquid
+++ b/snippets/shipping-progress-bar.liquid
@@ -1,0 +1,31 @@
+{% comment %}
+  Renders a progress bar showing how close the cart is to free shipping.
+  Usage:
+  {% render 'shipping-progress-bar', threshold: 2500 %}
+  threshold is the free shipping requirement in cents (default 2500 = $25.00)
+{% endcomment %}
+{% assign threshold = threshold | default: 2500 %}
+{% assign cart_total = cart.total_price %}
+{% if cart_total >= threshold %}
+  <div class="shipping-progress">
+    <div class="shipping-progress__track">
+      <div class="shipping-progress__fill" style="width:100%"></div>
+    </div>
+    <p class="shipping-progress__text">You've qualified for free shipping!</p>
+  </div>
+{% else %}
+  {% assign remaining = threshold | minus: cart_total %}
+  {% assign percent = cart_total | times: 100 | divided_by: threshold %}
+  <div class="shipping-progress">
+    <div class="shipping-progress__track">
+      <div class="shipping-progress__fill" style="width: {{ percent }}%"></div>
+    </div>
+    <p class="shipping-progress__text">You're {{ remaining | money }} away from free shipping</p>
+  </div>
+{% endif %}
+<style>
+.shipping-progress{margin-bottom:1rem;}
+.shipping-progress__track{background:#eee;height:8px;position:relative;border-radius:4px;overflow:hidden;}
+.shipping-progress__fill{background:#000;height:100%;border-radius:4px;}
+.shipping-progress__text{margin-top:0.5rem;font-size:0.875rem;}
+</style>

--- a/templates/page.frequently-bought.json
+++ b/templates/page.frequently-bought.json
@@ -1,0 +1,11 @@
+{
+  "sections": {
+    "main": {
+      "type": "frequently-bought",
+      "settings": {}
+    }
+  },
+  "order": [
+    "main"
+  ]
+}


### PR DESCRIPTION
## Summary
- show free-shipping progress in cart drawer
- add "Frequently bought together" page and section listing related SKUs

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894e08c71408328bfbe0bd38eb047c8