### PR TITLE
Move shipping progress bar above cart and enlarge

### DIFF
--- a/snippets/cart-drawer.liquid
+++ b/snippets/cart-drawer.liquid
@@ -55,6 +55,7 @@
           {%- endif -%}
         </div>
       {%- endif -%}
+      {% render 'shipping-progress-bar', threshold: 2500 %}
       <div class="drawer__header">
         <h2 class="drawer__heading">{{ 'sections.cart.title' | t }}</h2>
         <button
@@ -371,8 +372,6 @@
           </details>
         {%- endif -%}
 
-        <!-- Start blocks -->
-        {% render 'shipping-progress-bar', threshold: 2500 %}
         <!-- Subtotals -->
 
         <div class="cart-drawer__footer" {{ block.shopify_attributes }}>

--- a/snippets/shipping-progress-bar.liquid
+++ b/snippets/shipping-progress-bar.liquid
@@ -25,7 +25,7 @@
 {% endif %}
 <style>
 .shipping-progress{margin-bottom:1rem;}
-.shipping-progress__track{background:#eee;height:8px;position:relative;border-radius:4px;overflow:hidden;}
-.shipping-progress__fill{background:#000;height:100%;border-radius:4px;}
-.shipping-progress__text{margin-top:0.5rem;font-size:0.875rem;}
+.shipping-progress__track{background:#eee;height:16px;position:relative;border-radius:8px;overflow:hidden;}
+.shipping-progress__fill{background:#000;height:100%;border-radius:8px;}
+.shipping-progress__text{margin-top:0.5rem;font-size:1rem;}
 </style>


### PR DESCRIPTION
## Summary
- Move shipping progress bar from footer to top of cart drawer above the heading
- Increase progress bar height and text font size
- Keep dynamic fill based on cart total

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_6894f0cb5ba48328b45a8d90353a75b0